### PR TITLE
chore: new cli arg + updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,44 @@ python run_syncnet.py --videofile /path/to/video.mp4 --reference name_of_video -
 python run_visualise.py --videofile /path/to/video.mp4 --reference name_of_video --data_dir /path/to/output
 ```
 
+## Parameters
+
+### run_pipeline.py parameters:
+- `--min_face_size`: Minimum face size in pixels (default: 100). Reduce this value for videos with smaller faces.
+- `--facedet_scale`: Scale factor for face detection (default: 0.25)
+- `--crop_scale`: Scale bounding box (default: 0.40)
+- `--min_track`: Minimum facetrack duration (default: 100 frames)
+
+Example with smaller faces:
+```
+python run_pipeline.py --videofile /path/to/video.mp4 --reference name_of_video --data_dir /path/to/output --min_face_size 50
+```
+
+## Troubleshooting
+
+### Issue: Empty pycrop directory / No bounding boxes in output video
+
+**Symptoms:**
+- `$DATA_DIR/pycrop/$REFERENCE/` directory is empty
+- No bounding boxes appear in the output video
+- Face detection appears to work (faces are detected in console output)
+
+**Cause:** The detected faces are smaller than the minimum face size threshold.
+
+**Solution:** 
+1. Check your detected face sizes by examining the face detection output
+2. Reduce the `--min_face_size` parameter in `run_pipeline.py`
+3. For videos with small faces (< 100 pixels), try `--min_face_size 50` or lower
+
+**Example fix:**
+```bash
+# Instead of default parameters
+python run_pipeline.py --videofile data/chunk_003.mp4 --reference chunk_003 --data_dir data/test/
+
+# Use lower minimum face size
+python run_pipeline.py --videofile data/chunk_003.mp4 --reference chunk_003 --data_dir data/test/ --min_face_size 50
+```
+
 Outputs:
 ```
 $DATA_DIR/pycrop/$REFERENCE/*.avi - cropped face tracks

--- a/detectors/s3fd/box_utils.py
+++ b/detectors/s3fd/box_utils.py
@@ -35,7 +35,7 @@ def nms_(dets, thresh):
         inds = np.where(ovr <= thresh)[0]
         order = order[inds + 1]
 
-    return np.array(keep).astype(np.int)
+    return np.array(keep).astype(int)
 
 
 def decode(loc, priors, variances):

--- a/run_syncnet.py
+++ b/run_syncnet.py
@@ -35,11 +35,23 @@ flist.sort()
 # ==================== GET OFFSETS ====================
 
 dists = []
+offsets = []
+confs = []
 for idx, fname in enumerate(flist):
     offset, conf, dist = s.evaluate(opt,videofile=fname)
+    offsets.append(offset)
+    confs.append(conf)
     dists.append(dist)
       
 # ==================== PRINT RESULTS TO FILE ====================
 
 with open(os.path.join(opt.work_dir,opt.reference,'activesd.pckl'), 'wb') as fil:
     pickle.dump(dists, fil)
+
+# ==================== SAVE OFFSETS TO TXT FILE ====================
+
+with open(os.path.join(opt.work_dir,opt.reference,'offsets.txt'), 'w') as fil:
+    for idx, (offset, conf) in enumerate(zip(offsets, confs)):
+        fil.write('TRACK %d: OFFSET %d, CONF %.3f\n'%(idx, offset, conf))
+
+print("Offset results saved to %s" % os.path.join(opt.work_dir,opt.reference,'offsets.txt'))

--- a/run_visualise.py
+++ b/run_visualise.py
@@ -69,7 +69,7 @@ for fidx, fname in enumerate(flist):
 
 	for face in faces[fidx]:
 
-		clr = max(min(face['conf']*25,255),0)
+		clr = int(max(min(face['conf']*25,255),0))
 
 		cv2.rectangle(image,(int(face['x']-face['s']),int(face['y']-face['s'])),(int(face['x']+face['s']),int(face['y']+face['s'])),(0,clr,255-clr),3)
 		cv2.putText(image,'Track %d, Conf %.3f'%(face['track'],face['conf']), (int(face['x']-face['s']),int(face['y']-face['s'])),cv2.FONT_HERSHEY_SIMPLEX,0.5,(255,255,255),2)


### PR DESCRIPTION
This pull request introduces several updates to improve usability, debugging, and code quality across the project. Key changes include the addition of new documentation to assist users with parameter configuration and troubleshooting, enhancements to result output in `run_syncnet.py`, and minor code improvements for compatibility and readability.

### Documentation Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R76): Added a new "Parameters" section for `run_pipeline.py` with explanations of key parameters like `--min_face_size`, `--facedet_scale`, and `--crop_scale`. Also added a "Troubleshooting" section to guide users in resolving issues such as missing bounding boxes in output videos.

### Output Improvements:
* [`run_syncnet.py`](diffhunk://#diff-4d8e67d56c1fd126e72c2c924c7ca323ce16ab4e04cbde16c30487ec94747205R38-R57): Added functionality to save offset results to a text file (`offsets.txt`) with detailed information about track offsets and confidence scores. This improves the ability to analyze and debug results.

### Code Quality Improvements:
* [`detectors/s3fd/box_utils.py`](diffhunk://#diff-eac4214ec68800fc6296db6aba76ec45f5e13a1d578f6bb903aad1309622d9acL38-R38): Replaced the deprecated `np.int` with `int` for better compatibility with newer versions of NumPy.
* [`run_visualise.py`](diffhunk://#diff-75998a98332d68021565234971c1ae34010c7ef822e9370c8c0248e52aa08b8fL72-R72): Ensured the color value in face bounding box visualization is explicitly cast to an integer, improving code clarity and preventing potential type issues.